### PR TITLE
 Added child wallet replacement, emergency withdrawal, and admin management features

### DIFF
--- a/contracts/StacksTrust.clar
+++ b/contracts/StacksTrust.clar
@@ -146,3 +146,140 @@
         (ok (map-delete child-account {parent: parent, child-name: child-name}))
     )
 )
+
+;; function to replace child wallet by parent
+(define-public (replace-child-wallet (parent principal) (child-name (string-ascii 24)) (new-wallet principal))
+    (let 
+        (
+            (current-child-account (unwrap!
+                                        (map-get? child-account {parent: parent, child-name: child-name})
+                                        (err "child-account-does-not-exist")
+                                    )
+            )
+            (current-child-admins (get admins current-child-account))
+            (current-child-wallet (get child-wallet current-child-account))
+        )
+        (asserts!
+            (is-some (index-of current-child-admins tx-sender))
+            (err "err-unauthorized")
+        )
+        (ok (map-set child-account {parent: tx-sender, child-name: child-name}
+            (merge
+                current-child-account
+                {child-wallet: new-wallet}
+            )
+        ))
+    )
+)
+
+;; function to withdraw funds by parent or admin incase of emergency
+(define-public (emergency-withdraw (parent principal) (child-name (string-ascii 24)))
+    (let
+        (
+            (current-total-fees-earned (var-get total-fees-earned))
+            (current-child-account (unwrap!
+                                        (map-get? child-account {parent: parent, child-name: child-name})
+                                        (err "child-account-does-not-exist")
+                                    )
+            )
+            (current-child-balance (get balance current-child-account))
+            (current-child-unlock-height (get unlock-height current-child-account))
+            (current-emergency-withdrawal-fee 
+                (if 
+                    (>= block-height current-child-unlock-height) 
+                    (/ (* current-child-balance emergency-withrawal-fee) u100)
+                    (/ (* current-child-balance withdrawal-fee) u100)
+                )
+
+            )
+            (current-child-emergency-withdrawal (- current-child-balance current-emergency-withdrawal-fee))
+            (current-child-admins (get admins current-child-account))
+        )
+        (asserts!
+            (or (is-eq tx-sender parent) (is-some (index-of current-child-admins tx-sender)))
+            (err "err-unauthorized-withdrawal")
+        )
+        (unwrap!
+            (as-contract (stx-transfer? current-child-emergency-withdrawal tx-sender tx-sender))
+            (err "unable-to-send-stx-to-parent-or-admin")
+        )
+        (var-set total-fees-earned (+ current-total-fees-earned current-emergency-withdrawal-fee))
+        (ok (map-delete child-account {parent: parent, child-name: child-name}))
+    )
+)
+
+(define-public (withdraw-earnings)
+    (let
+        (
+            (current-total-fees-earned (var-get total-fees-earned))
+        )
+        (asserts! (is-eq tx-sender deployer) (err "err-unauthorized"))
+        (asserts! (> current-total-fees-earned u0) (err "err-earnings-empty"))
+        (unwrap! 
+            (as-contract (stx-transfer? current-total-fees-earned tx-sender deployer))
+            (err "err-unable-to-transfer-earnings")    
+        )
+        (ok (var-set total-fees-earned u0))
+    )
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Admin Functions ;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-public (add-child-admin (parent principal) (child-name (string-ascii 24)) (admin principal))
+    (let
+        (
+            (current-child-account (unwrap!
+                                        (map-get? child-account {parent: parent, child-name: child-name})
+                                        (err "child-account-does-not-exist")
+                                    )
+            )
+            (current-child-admins (get admins current-child-account))
+        )
+        (asserts! (is-eq tx-sender parent) (err "err-unauthorized"))
+        (asserts! (is-none (index-of current-child-admins admin)) (err "err-admin-already-exist"))
+        (ok (map-set child-account {parent: tx-sender, child-name: child-name}
+            (merge
+                current-child-account
+                {admins: (unwrap!
+                            (as-max-len? (append current-child-admins admin) u5)
+                            (err "err-unable-to-add-admin")
+                        )
+                }
+            )
+        ))
+    )
+)
+
+(define-public (remove-child-admin (parent principal) (child-name (string-ascii 24)) (admin principal))
+    (let
+        (
+            (current-child-account (unwrap!
+                                        (map-get? child-account {parent: parent, child-name: child-name})
+                                        (err "child-account-does-not-exist")
+                                    )
+            )
+            (current-child-admins (get admins current-child-account))
+        )
+        (asserts! (is-eq tx-sender parent) (err "err-unauthorized"))
+        (asserts! (is-some (index-of current-child-admins admin)) (err "err-admin-does-not-exist"))
+        (ok (map-set child-account {parent: parent, child-name: child-name}
+                (merge
+                    current-child-account
+                    {admins: (get new-admin-list (fold remove-admin current-child-admins {compare-to: admin, new-admin-list: (list)}))
+                    }
+                )
+            )
+        )
+    )
+)
+
+(define-private (remove-admin (list-admin principal) (admin-tracker {compare-to: principal, new-admin-list: (list 5 principal)}))
+    (merge admin-tracker {new-admin-list:
+        (if (is-eq list-admin (get compare-to admin-tracker))
+            (get new-admin-list admin-tracker)
+            (unwrap-panic (as-max-len? (append (get new-admin-list admin-tracker) list-admin) u5))
+        )}
+    )
+)


### PR DESCRIPTION

#### **Title**: Add Admin Management, Emergency Withdrawal, and Wallet Replacement Features  

#### **Description**  
This pull request enhances the **Offspring Will Smart Contract** by introducing new functionalities that improve flexibility, security, and administrative control over child accounts. The newly implemented features allow parents to replace a child’s wallet, enable emergency withdrawals by authorized admins, and manage child account administrators.  

#### **Key Enhancements**  

1. **Replace Child Wallet**  
   - Parents can update their child's wallet address in case of a lost or compromised wallet.  
   - Only parents or assigned administrators can perform this action.  

2. **Emergency Withdrawals**  
   - Parents or admins can withdraw funds before maturity in urgent situations.  
   - Higher fees apply if funds are withdrawn before the lock period expires.  
   - Ensures financial flexibility in emergencies while discouraging premature withdrawals.  

3. **Admin Management**  
   - Parents can now assign or remove up to **five** administrators for each child account.  
   - Admins assist in managing child accounts but cannot withdraw funds for personal use.  
   - Enhanced access control prevents unauthorized actions while maintaining flexibility.  

4. **Earnings Withdrawal for Contract Deployer**  
   - The deployer can now withdraw accumulated contract fees.  
   - Ensures proper fund management and incentivizes the contract’s maintenance.  

#### **Implemented Functions**  

- `replace-child-wallet`: Allows a parent to update the child’s wallet.  
- `emergency-withdraw`: Enables parents or admins to withdraw funds before maturity with applicable fees.  
- `withdraw-earnings`: Allows the contract deployer to withdraw accumulated fees.  
- `add-child-admin`: Enables a parent to assign an administrator.  
- `remove-child-admin`: Allows a parent to remove an assigned administrator.  